### PR TITLE
修改文章「學習資源彙整」

### DIFF
--- a/_posts/2022-05-15-學習資源彙整.md
+++ b/_posts/2022-05-15-學習資源彙整.md
@@ -38,11 +38,12 @@ tags:
 * [使用 NVDA 瀏覽 Readmoo 讀墨電子書](https://class.kh.edu.tw/19061/bulletin/msg_view/330)
 * [使用 NVDA 瀏覽博客來電子書](https://class.kh.edu.tw/19061/bulletin/msg_view/397)
 
-## 數學教材點譯
+## 教材製作
 
 * [數學教材點譯筆記](https://github.com/huanlin/VisualAids/blob/main/MathML/%E6%95%B8%E5%AD%B8%E6%95%99%E6%9D%90%E8%BD%89%E8%AD%AF%E7%AD%86%E8%A8%98/%E6%95%B8%E5%AD%B8%E6%95%99%E6%9D%90%E8%BD%89%E8%AD%AF%E7%AD%86%E8%A8%98.md)
+* [111.06.08 [南大] 視障生通用教材製作]()
+* [111.06.11 [南大] 視障生通用數學教材製作](https://class.kh.edu.tw/19061/bulletin/msg_view/680)
 * [重度視障者的數學讀寫／教材製作](https://class.kh.edu.tw/19061/page/view/19) by 視覺障礙輔助科技筆記本
-* [2021.09.26 視障數學教材編輯 [視巡群組分享會]](https://www.youtube.com/watch?v=6FBsuVRm3g8)
 
 ## YouTube 頻道
 
@@ -60,6 +61,12 @@ tags:
 
 ## 口述影像
 
- * [視覺障礙輔助科技筆記本：口述影像連結整理](https://class.kh.edu.tw/19061/bulletin/msg_view/349)
- * [臺北市立圖書館：用心看電影](https://blind.tpml.edu.tw/sp.asp?xdurl=superxd/go2movie.asp&mp=10&ctNode=295)
- * [國立臺灣圖書館：電影聽賞](https://viis.ntl.edu.tw/viresouces/lp?cat=%E9%9B%BB%E5%BD%B1%E8%81%BD%E8%B3%9E)
+* [口述影像 | 教育部華文視障電子圖書網]()
+
+收集超過一百部口述電影，包括〈放牛班的春天》、刺激1995、泰坦尼克号等。
+
+* [視覺障礙輔助科技筆記本：口述影像連結整理](https://class.kh.edu.tw/19061/bulletin/msg_view/349)
+* [臺北市立圖書館：用心看電影](https://blind.tpml.edu.tw/sp.asp?xdurl=superxd/go2movie.asp&mp=10&ctNode=295)
+* [國立臺灣圖書館：電影聽賞](https://viis.ntl.edu.tw/viresouces/lp?cat=%E9%9B%BB%E5%BD%B1%E8%81%BD%E8%B3%9E)
+ 
+ 

--- a/_posts/2022-05-15-學習資源彙整.md
+++ b/_posts/2022-05-15-學習資源彙整.md
@@ -41,7 +41,7 @@ tags:
 ## 教材製作
 
 * [數學教材點譯筆記](https://github.com/huanlin/VisualAids/blob/main/MathML/%E6%95%B8%E5%AD%B8%E6%95%99%E6%9D%90%E8%BD%89%E8%AD%AF%E7%AD%86%E8%A8%98/%E6%95%B8%E5%AD%B8%E6%95%99%E6%9D%90%E8%BD%89%E8%AD%AF%E7%AD%86%E8%A8%98.md)
-* [111.06.08 [南大] 視障生通用教材製作]()
+* [111.06.08 [南大] 視障生通用教材製作](https://class.kh.edu.tw/19061/bulletin/msg_view/679)
 * [111.06.11 [南大] 視障生通用數學教材製作](https://class.kh.edu.tw/19061/bulletin/msg_view/680)
 * [重度視障者的數學讀寫／教材製作](https://class.kh.edu.tw/19061/page/view/19) by 視覺障礙輔助科技筆記本
 


### PR DESCRIPTION
標題「數學教材點譯」，更名為「教材製作」。

內容新增「國立臺南大學視障生教材製作研習」相關連結。

內容刪除，2021.09.26 視障數學教材編輯 [視巡群組分享會]。

標題「口述影像」，內容新增一個來源，教育部華文視障電子圖書網。